### PR TITLE
Fix critical plugin loading and usage bug

### DIFF
--- a/src/results-modal.ts
+++ b/src/results-modal.ts
@@ -202,7 +202,7 @@ export class ResultsModal extends Modal {
   }
 
   private insertRelativeToImage(position: 'above' | 'below') {
-    if (!this.result.noteContext?.matchIndex || this.result.noteContext.matchLength == null) {
+    if (this.result.noteContext?.matchIndex == null || this.result.noteContext.matchLength == null) {
       this.editor.replaceSelection(this.formatContent(this.result.content, 'cursor'));
       return;
     }
@@ -217,7 +217,7 @@ export class ResultsModal extends Modal {
   }
 
   private replaceImageWithCallout() {
-    if (!this.result.noteContext?.matchIndex || this.result.noteContext.matchLength == null) {
+    if (this.result.noteContext?.matchIndex == null || this.result.noteContext.matchLength == null) {
       this.editor.replaceSelection(this.formatContent(this.result.content, 'callout'));
       return;
     }


### PR DESCRIPTION
Fixes a bug where image insertion/replacement failed when the image was at the start of a note (index 0).

The original condition `!this.result.noteContext?.matchIndex` incorrectly treated a `matchIndex` of `0` as falsy, causing the functions to fall back to `replaceSelection` instead of performing the intended relative insertion or replacement. This fix ensures `0` is correctly recognized as a valid index.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b4d33e4-f166-47fe-a666-012599cfaad7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b4d33e4-f166-47fe-a666-012599cfaad7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

